### PR TITLE
Add typescript checking

### DIFF
--- a/.github/workflows/azure-static-web-app.yml
+++ b/.github/workflows/azure-static-web-app.yml
@@ -18,6 +18,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Npm install
+        working-directory: frontend
+        run: npm ci
+      - name: Type check
+        working-directory: frontend
+        run: npx tsc
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,9 +22,7 @@
   },
   "scripts": {
     "start": "parcel src/index.html",
-    "build": "parcel build src/index.html",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "build": "parcel build src/index.html"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/src/definitions.d.ts
+++ b/frontend/src/definitions.d.ts
@@ -1,0 +1,2 @@
+// silences typescript complaining about importing images
+declare module '*.png'

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />


### PR DESCRIPTION
The Parcel bundler does not do a TypeScript check. This is now added as an explicit step which blocks merging and deploying.