### PR TITLE
Split verblijfsobject gebruikersdoel

### DIFF
--- a/frontend/src/components/aggregated-area-data.tsx
+++ b/frontend/src/components/aggregated-area-data.tsx
@@ -1,7 +1,7 @@
 import {AppState} from "../services/appState";
 import {createElement as h} from "react";
 import {DtBold} from "./pand-display";
-import {Bag2DVerblijfsobject} from "../services/bag-verblijfsobject";
+import {Verblijfsobject} from "../services/bag-verblijfsobject";
 import {Bag2DPand} from "../services/bag2d";
 
 
@@ -17,15 +17,15 @@ export const AggregatedAreaData = ({appState}: {appState: AppState}) => (
         // TODO: does not include panden with no verblijfsobject, like factory floors
         h('dd', {}, sumVloeroppervlak(appState.verblijfsobjecten).toLocaleString('nl-NL') + " m²"),
         h(DtBold, {}, "Gebruiksdoelen"),
-        h('dd', {}, Object.entries(gebruiksdoelen(appState.verblijfsobjecten))
+        h('dd', {}, Object.entries(gebruiksdoelenOverzicht(appState.verblijfsobjecten))
                 .map(([gebruiksdoel, aantal]) => h('div', {key: gebruiksdoel}, `${gebruiksdoel} (${aantal}x)`))
         )
     )
 )
 
-const sumVloeroppervlak = (verblijfsobjecten: Bag2DVerblijfsobject[]): number =>
+const sumVloeroppervlak = (verblijfsobjecten: Verblijfsobject[]): number =>
     verblijfsobjecten
-        .map(verblijfsobject => verblijfsobject.properties.oppervlakte)
+        .map(verblijfsobject => verblijfsobject.oppervlakte)
         .reduce((acc, val) => acc + val, 0)
 
 const averageBouwjaar = (panden: Bag2DPand[]) => {
@@ -44,10 +44,9 @@ const averageBouwjaar = (panden: Bag2DPand[]) => {
     return Math.round(average)
 }
 
-const gebruiksdoelen = (verblijfsobjecten: Bag2DVerblijfsobject[]): {[gebruiksdoel: string]: number} =>
+const gebruiksdoelenOverzicht = (verblijfsobjecten: Verblijfsobject[]): {[gebruiksdoel: string]: number} =>
     verblijfsobjecten
-        // TODO: split comma-separated values
-        .map(verblijfsobject => verblijfsobject.properties.gebruiksdoel)
+        .flatMap(verblijfsobject => verblijfsobject.gebruiksdoelen)
         .reduce((acc, gebruiksdoel) => ({
             ...acc,
             // @ts-ignore

--- a/frontend/src/components/pand-display.tsx
+++ b/frontend/src/components/pand-display.tsx
@@ -2,7 +2,7 @@ import {KleinVerbruikPerPostcode, PandData} from "../services/appState";
 import {Bag2DPandProperties} from "../services/bag2d";
 import React, {createElement, Fragment, FunctionComponent, PropsWithChildren, ReactElement} from "react";
 import {Bag3dProperties} from "../services/3dbag_old";
-import {VerblijfsobjectProperties} from "../services/bag-verblijfsobject";
+import {Verblijfsobject} from "../services/bag-verblijfsobject";
 import {PostcodeKleinverbruikProperties} from "../services/enexis";
 
 
@@ -16,8 +16,8 @@ export const PandDataDisplay = ({pandData}: {pandData: PandData}) => (
         <h2>Verblijfsobjecten ({pandData.bag2dPand?.properties.aantal_verblijfsobjecten})</h2>
         {pandData.verblijfsobjecten.map((verblijfsobject, index) => (
             <>
-                <h3>Verblijfsobject {verblijfsobjectLabel(verblijfsobject.properties)}</h3>
-                <PropertyList props={verblijfsobject.properties} specs={verblijfsobjectDisplaySpec} defaultSpec={bagDefaultDisplaySpec}/>
+                <h3>Verblijfsobject {verblijfsobjectLabel(verblijfsobject)}</h3>
+                <PropertyList props={verblijfsobject} specs={verblijfsobjectDisplaySpec} defaultSpec={bagDefaultDisplaySpec}/>
             </>
         ))}
 
@@ -75,7 +75,7 @@ const KleinverbruikDisplay = ({kleinverbruik}: {kleinverbruik: {[postcode: strin
     return result
 }
 
-const verblijfsobjectLabel = (verblijfsObject: VerblijfsobjectProperties): string => {
+const verblijfsobjectLabel = (verblijfsObject: Verblijfsobject): string => {
     let result = `${verblijfsObject.openbare_ruimte} ${verblijfsObject.huisnummer}`
 
     if (verblijfsObject.toevoeging) {
@@ -137,6 +137,7 @@ const Property = ({objectKey, value, spec}: { objectKey: string, value: any, spe
     }
 
     if (spec.is_url) {
+        value = value.replace('http://', 'https://')
         value = <a href={value}>{value}</a>
     }
 
@@ -149,10 +150,12 @@ const Property = ({objectKey, value, spec}: { objectKey: string, value: any, spe
         label = spec.label
     }
 
+    const values: any[] =  Array.isArray(value) ? value : [value]
+
     return (
         <>
             <DtBold>{label}</DtBold>
-            <dd>{value}</dd>
+            {values.map((v: any, i: number) => <dd key={i}>{v}</dd>)}
         </>
     )
 }
@@ -195,7 +198,7 @@ const bag2dDisplaySpec: Partial<{[key in keyof Bag2DPandProperties]: Partial<Dis
     }
 }
 
-const verblijfsobjectDisplaySpec: Partial<{[key in keyof VerblijfsobjectProperties]: Partial<DisplaySpec>}> = {
+const verblijfsobjectDisplaySpec: Partial<{[key in keyof Verblijfsobject]: Partial<DisplaySpec>}> = {
     rdf_seealso: {
         is_url: true,
     },
@@ -208,6 +211,7 @@ const verblijfsobjectDisplaySpec: Partial<{[key in keyof VerblijfsobjectProperti
     pandstatus: {
         visible: false
     },
+    // is this always the same as pand?
     bouwjaar: {
         visible: false
     }

--- a/frontend/src/services/appState.ts
+++ b/frontend/src/services/appState.ts
@@ -2,7 +2,7 @@ import {Bag2DPand, getBag2dPanden} from "./bag2d";
 import {useState} from "react";
 import {LatLngBounds} from "leaflet";
 import {Bag3DFeature, getBag3dFeatures} from "./3dbag_old";
-import {Bag2DVerblijfsobject, getBagVerblijfsobjecten} from "./bag-verblijfsobject";
+import {getBagVerblijfsobjecten, Verblijfsobject} from "./bag-verblijfsobject";
 import {
     getPostcodeKleinverbruik,
     PostcodeKleinverbruikFeature,
@@ -13,7 +13,7 @@ import {
 export interface AppState {
     bag2dPanden: Bag2DPand[]
     bag3dFeatures: Bag3DFeature[]
-    verblijfsobjecten: Bag2DVerblijfsobject[]
+    verblijfsobjecten: Verblijfsobject[]
     postcodeKleinverbruik: {
         elektricity: PostcodeKleinverbruikFeature[]
         gas: PostcodeKleinverbruikFeature[]
@@ -33,7 +33,7 @@ const initialState: AppState = {
 export type PandData = {
     bag2dPand?: Bag2DPand,
     bag3dPand?: Bag3DFeature,
-    verblijfsobjecten: Bag2DVerblijfsobject[],
+    verblijfsobjecten: Verblijfsobject[],
     kleinverbruik: {
         [postcode: string]: KleinVerbruikPerPostcode
     }
@@ -124,10 +124,10 @@ export const useAppState = () => {
         const bag3dPand = appState.bag3dFeatures
             .find(bag3dPand => bag3dPand.properties.identificatie === `NL.IMBAG.Pand.${pandId}`)
         const verblijfsobjecten = appState.verblijfsobjecten
-            .filter(bagVerblijfsobject => bagVerblijfsobject.properties.pandidentificatie === pandId)
+            .filter(verblijfsobject => verblijfsobject.pandidentificatie === pandId)
 
         const postcodes = new Set(
-            verblijfsobjecten.map(verblijfsobject => verblijfsobject.properties.postcode)
+            verblijfsobjecten.map(verblijfsobject => verblijfsobject.postcode)
         )
 
         const kleinverbruik: {[postcode: string]: KleinVerbruikPerPostcode} = {}

--- a/frontend/src/services/bag-verblijfsobject.ts
+++ b/frontend/src/services/bag-verblijfsobject.ts
@@ -1,22 +1,42 @@
 import {LatLngBounds} from "leaflet";
 import {BAG_MAX_PANDEN, BoundingBox, boundingBoxToBAG} from "./bag2d";
-import {Point} from "geojson";
+import {Point, Position} from "geojson";
 
-export type Bag2DVerblijfsobject = {
-    type: "Feature",
-    id: string // e.g. "verblijfsobject.144b58ad-1e01-4025-b275-db34fc19ebf7"
-    properties: VerblijfsobjectProperties,
-    bbox: BoundingBox,
-    geometry: Point,
+// https://imbag.github.io/praktijkhandleiding/artikelen/welk-gebruiksdoel-moet-worden-geregistreerd
+export enum GebruiksDoel {
+    // Gebruiksfunctie voor het wonen
+    woonfunctie = 'woonfunctie',
+    //Gebruiksfunctie voor het samenkomen van personen voor kunst, cultuur, godsdienst, communicatie, kinderopvang, het verstrekken van consumpties voor het gebruik ter plaatse of het aanschouwen van sport
+    bijeenkomstfunctie = 'bijeenkomstfunctie',
+    // Gebruiksfunctie voor het dwangverblijf van personen
+    celfunctie = 'celfunctie',
+    // Gebruiksfunctie voor medisch onderzoek, verpleging, verzorging of behandeling
+    gezondheidszorgfunctie = 'gezondheidszorgfunctie',
+    // Gebruiksfunctie voor het bedrijfsmatig bewerken of opslaan van materialen en goederen, of voor agrarische doeleinden
+    industriefunctie = 'industriefunctie',
+    // Gebruiksfunctie voor administratie
+    kantoorfunctie = 'kantoorfunctie',
+    // Gebruiksfunctie voor het bieden van recreatief verblijf of tijdelijk onderdak aan personen
+    logiesfunctie = 'logiesfunctie',
+    // Gebruiksfunctie voor het geven van onderwijs
+    onderwijsfunctie = 'onderwijsfunctie',
+    // Gebruiksfunctie voor het beoefenen van sport
+    sportfunctie = 'sportfunctie',
+    // Gebruiksfunctie voor het verhandelen van materialen, goederen of diensten
+    winkelfunctie = 'winkelfunctie',
+    // Niet in dit lid benoemde gebruiksfunctie voor activiteiten waarbij het verblijven van personen een ondergeschikte rol speelt
+    overige_gebruiksfunctie = 'overige gebruiksfunctie',
 }
 
-export type VerblijfsobjectProperties = {
+export type Verblijfsobject = {
+    feature_id: string // e.g. "verblijfsobject.144b58ad-1e01-4025-b275-db34fc19ebf7"
+    position: Position,
     identificatie: string, // example: "0772010000726364"
     pandidentificatie: string, // example: "0772100000306503"
     rdf_seealso: string, // url
     oppervlakte: number,
     status: string,
-    gebruiksdoel: string,
+    gebruiksdoelen: GebruiksDoel[],
     openbare_ruimte: string,
     huisnummer: number,
     huisletter: string,
@@ -25,10 +45,35 @@ export type VerblijfsobjectProperties = {
     woonplaats: string,
     bouwjaar: string,
     pandstatus: string,
-    // probably incomplete
 }
 
-export async function getBagVerblijfsobjecten(boundingBox: LatLngBounds): Promise<Bag2DVerblijfsobject[]> {
+type VerblijfsobjectFeature = {
+    type: "Feature",
+    id: string // e.g. "verblijfsobject.144b58ad-1e01-4025-b275-db34fc19ebf7"
+    properties: VerblijfsobjectProperties,
+    bbox: BoundingBox,
+    geometry: Point,
+}
+
+// see https://service.pdok.nl/lv/bag/wfs/v2_0?version=2.0.0&service=WFS&request=DescribeFeatureType&typename=bag:verblijfsobject
+type VerblijfsobjectProperties = {
+    identificatie: string, // example: "0772010000726364"
+    pandidentificatie: string, // example: "0772100000306503"
+    rdf_seealso: string, // url
+    oppervlakte: number,
+    status: string,
+    gebruiksdoel: string,
+    openbare_ruimte: string, // street name
+    huisnummer: number,
+    huisletter: string,
+    toevoeging: string,
+    postcode: string, // 1111AA
+    woonplaats: string,
+    bouwjaar: string,
+    pandstatus: string,
+}
+
+export async function getBagVerblijfsobjecten(boundingBox: LatLngBounds): Promise<Verblijfsobject[]> {
     const params = new URLSearchParams({
         request: "GetFeature",
         service: "WFS",
@@ -59,5 +104,21 @@ export async function getBagVerblijfsobjecten(boundingBox: LatLngBounds): Promis
         throw new Error("Maximum aantal verblijfsobjecten overschreden")
     }
 
-    return body.features
+    return body.features.map(postProcessing)
+}
+
+// Create a flatter, more strongly typed object
+const postProcessing = (verblijfsobject: VerblijfsobjectFeature): Verblijfsobject => {
+    // unpack into new object so that any unknown/added properties are preserved
+    let result: Verblijfsobject = {
+        ...verblijfsobject.properties,
+        feature_id: verblijfsobject.id,
+        position: verblijfsobject.geometry.coordinates,
+        gebruiksdoelen: verblijfsobject.properties.gebruiksdoel.split(",").filter(Boolean) as GebruiksDoel[],
+    }
+
+    // @ts-ignore
+    delete result.gebruiksdoel
+
+    return result
 }


### PR DESCRIPTION
Gebruikersdoel is a CSV field. This change converts the field into an array of enums. This is handy for further classification in the simulation.

Also flatten the entire verblijfsobject since we're changing it anyways so there is no value in sticking to the original structure.